### PR TITLE
fix: Resolve build errors by restoring missing DTO

### DIFF
--- a/Doc-Patient-Backend/Controllers/AppointmentController.cs
+++ b/Doc-Patient-Backend/Controllers/AppointmentController.cs
@@ -1,4 +1,5 @@
 ﻿using Doc_Patient_Backend.Models;
+using Doc_Patient_Backend.Models.DTOs;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Cors;
 using Microsoft.AspNetCore.Mvc;

--- a/Doc-Patient-Backend/Models/DTOs/NewAppointment.cs
+++ b/Doc-Patient-Backend/Models/DTOs/NewAppointment.cs
@@ -1,0 +1,25 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace Doc_Patient_Backend.Models.DTOs
+{
+    public class NewAppointment
+    {
+        [Required]
+        public string PatientName { get; set; }
+
+        public string Email { get; set; }
+
+        [Required]
+        public string MobileNo { get; set; }
+
+        [Required]
+        public string City { get; set; }
+
+        [Required]
+        public string Address { get; set; }
+
+        [Required]
+        public DateTime AppointmentDate { get; set; }
+    }
+}


### PR DESCRIPTION
This commit resolves build failures caused by an incomplete refactoring.

- Restored the `NewAppointment` DTO, which was removed but still referenced by the `AppointmentController`.
- Added the necessary `using` directive in `AppointmentController` to reference the `NewAppointment` DTO in its new location.
- Verified that all controllers now use the consolidated `ApplicationDbContext`.