### PR TITLE
fix: Add missing fields to appointments API for admin dashboard

### DIFF
--- a/Doc-Patient-Backend/Models/ApplicationDbContext.cs
+++ b/Doc-Patient-Backend/Models/ApplicationDbContext.cs
@@ -46,6 +46,8 @@ namespace Doc_Patient_Backend.Models
         public string PhoneNumber { get; set; }
         public string Address { get; set; }
         public string Status { get; set; } = "Scheduled"; // e.g., Scheduled, Completed, Canceled
+        public string PaymentStatus { get; set; } = "Pending";
+        public DateTime CreatedAt { get; set; }
 
         // Foreign key to link to the user (patient)
         public string PatientId { get; set; }

--- a/Doc-Patient-Backend/Models/DTOs/AppointmentDto.cs
+++ b/Doc-Patient-Backend/Models/DTOs/AppointmentDto.cs
@@ -13,6 +13,8 @@ namespace Doc_Patient_Backend.Models.DTOs
         public string PhoneNumber { get; set; }
         public string? Address { get; set; }
         public string Status { get; set; }
+        public string PaymentStatus { get; set; }
+        public DateTime CreatedAt { get; set; }
         public string PatientId { get; set; }
         public string DoctorId { get; set; }
     }

--- a/Doc-Patient-Backend/Services/AppointmentService.cs
+++ b/Doc-Patient-Backend/Services/AppointmentService.cs
@@ -33,6 +33,8 @@ namespace Doc_Patient_Backend.Services
                     PhoneNumber = a.PhoneNumber,
                     Address = a.Address,
                     Status = a.Status,
+                    PaymentStatus = a.PaymentStatus,
+                    CreatedAt = a.CreatedAt,
                     PatientId = a.PatientId,
                     DoctorId = a.DoctorId
                 })
@@ -55,6 +57,8 @@ namespace Doc_Patient_Backend.Services
                     PhoneNumber = a.PhoneNumber,
                     Address = a.Address,
                     Status = a.Status,
+                    PaymentStatus = a.PaymentStatus,
+                    CreatedAt = a.CreatedAt,
                     PatientId = a.PatientId,
                     DoctorId = a.DoctorId
                 })
@@ -102,7 +106,9 @@ namespace Doc_Patient_Backend.Services
                     Address = createAppointmentDto.Address,
                     PatientId = createAppointmentDto.PatientId,
                     DoctorId = createAppointmentDto.DoctorId,
-                    Status = "Scheduled"
+                    Status = "Scheduled",
+                    PaymentStatus = "Pending",
+                    CreatedAt = DateTime.UtcNow
                 };
 
                 _context.Appointments.Add(appointment);


### PR DESCRIPTION
This commit resolves the final blocker for the Admin Bookings page by adding the required `PaymentStatus` and `CreatedAt` fields to the API response.

- Updated the `Appointment` model in `ApplicationDbContext.cs` to include `PaymentStatus` and `CreatedAt` properties.
- Updated the `AppointmentDto.cs` to include the new properties.
- Updated the `AppointmentService` to set these new fields when an appointment is created and to map them correctly when appointments are fetched.