### PR TITLE
refactor: Move Appointment model to its own file

### DIFF
--- a/Doc-Patient-Backend/Models/ApplicationDbContext.cs
+++ b/Doc-Patient-Backend/Models/ApplicationDbContext.cs
@@ -44,32 +44,4 @@ namespace Doc_Patient_Backend.Models
                 .HasForeignKey(da => da.DoctorId);
         }
     }
-
-    [Table("Appointments")]
-    public class Appointment
-    {
-        [Key]
-        public int Id { get; set; }
-
-        [Required]
-        public string PatientName { get; set; }
-        public int? Age { get; set; }
-        public string? Gender { get; set; }
-        public DateTime StartTime { get; set; }
-        public DateTime EndTime { get; set; }
-        public string PhoneNumber { get; set; }
-        public string Address { get; set; }
-        public string Status { get; set; } = "Pending"; // New status flow: Pending -> Confirmed
-        public string? PaymentIntentId { get; set; }
-
-        // Foreign key to link to the user (patient)
-        public string PatientId { get; set; }
-        [ForeignKey("PatientId")]
-        public virtual ApplicationUser Patient { get; set; }
-
-        // Foreign key to link to the user (doctor)
-        public string DoctorId { get; set; }
-        [ForeignKey("DoctorId")]
-        public virtual ApplicationUser Doctor { get; set; }
-    }
 }

--- a/Doc-Patient-Backend/Models/Appointment.cs
+++ b/Doc-Patient-Backend/Models/Appointment.cs
@@ -1,0 +1,34 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Doc_Patient_Backend.Models
+{
+    [Table("Appointments")]
+    public class Appointment
+    {
+        [Key]
+        public int Id { get; set; }
+
+        [Required]
+        public string PatientName { get; set; }
+        public int? Age { get; set; }
+        public string? Gender { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+        public string PhoneNumber { get; set; }
+        public string Address { get; set; }
+        public string Status { get; set; } = "Pending"; // New status flow: Pending -> Confirmed
+        public string? PaymentIntentId { get; set; }
+
+        // Foreign key to link to the user (patient)
+        public string PatientId { get; set; }
+        [ForeignKey("PatientId")]
+        public virtual ApplicationUser Patient { get; set; }
+
+        // Foreign key to link to the user (doctor)
+        public string DoctorId { get; set; }
+        [ForeignKey("DoctorId")]
+        public virtual ApplicationUser Doctor { get; set; }
+    }
+}


### PR DESCRIPTION
Moved the Appointment model from ApplicationDbContext.cs to its own file, Appointment.cs, to improve code organization and maintainability. This change follows the single responsibility principle and makes the codebase easier to navigate.