### PR TITLE
fix: Secure patient appointment endpoint

### DIFF
--- a/Doc-Patient-Backend/Controllers/AppointmentController.cs
+++ b/Doc-Patient-Backend/Controllers/AppointmentController.cs
@@ -26,6 +26,15 @@ namespace Doc_Patient_Backend.Controllers
         [Authorize(Roles = "Admin,Patient")]
         public async Task<IActionResult> GetPatientAppointments(string patientId)
         {
+            var loggedInUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+            var isAdmin = User.IsInRole(UserRoles.Admin);
+
+            // A patient can only view their own appointments. An admin can view any patient's appointments.
+            if (!isAdmin && loggedInUserId != patientId)
+            {
+                return Forbid();
+            }
+
             var appointments = await appointmentService.GetUpcomingAppointmentsForPatientAsync(patientId);
             return Ok(appointments);
         }


### PR DESCRIPTION
This commit resolves a critical authorization vulnerability in the `GetPatientAppointments` endpoint.

Previously, any authenticated user with the 'Patient' role could access the appointments of any other patient by providing their ID.

The fix introduces a check that verifies if the logged-in user's ID matches the `patientId` from the URL, unless the user is an 'Admin'. If the IDs do not match, a `403 Forbidden` response is returned. This ensures that patients can only view their own data, maintaining data privacy.